### PR TITLE
Update simple_group_chat to expert_team 02.2-agents-chats.ipynb

### DIFF
--- a/02-semantic-kernel-agents/02.2-agents-chats.ipynb
+++ b/02-semantic-kernel-agents/02.2-agents-chats.ipynb
@@ -391,7 +391,7 @@
    "outputs": [],
    "source": [
     "question = \"What are some approaches to address climate change?\"\n",
-    "full_history = await run_group_chat(simple_group_chat, question)"
+    "full_history = await run_group_chat(expert_team, question)"
    ]
   },
   {


### PR DESCRIPTION
expert_team is defined but never get invoke. 
Update simple_group_chat to expert_team in second run_group_chat()

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Likely copy pasted and didn't update to the write value.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


## What to Check
Verify that the following are valid
```
question = "What are some approaches to address climate change?"
full_history = await run_group_chat(expert_team, question)
```

