### PR TITLE
fix: moved kernel service helper function down to example first used,…

### DIFF
--- a/04-process-framework/04.1-intro-to-processes.ipynb
+++ b/04-process-framework/04.1-intro-to-processes.ipynb
@@ -333,35 +333,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4a5df4f3-14b3-4b47-834b-1bd9b8e6e1aa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def create_kernel_with_service(service_id=\"default\"):\n",
-    "    \"\"\"Create a kernel with Azure OpenAI or OpenAI service.\"\"\"\n",
-    "    kernel = Kernel()\n",
-    "\n",
-    "    if (os.getenv(\"AZURE_OPENAI_ENDPOINT\")):\n",
-    "        print(\"Using Azure OpenAI service\")\n",
-    "        kernel.add_service(\n",
-    "            AzureChatCompletion(service_id=service_id)\n",
-    "        )\n",
-    "    else:\n",
-    "        raise ValueError(\n",
-    "            \"No AI service credentials found. Please set up your .env file.\"\n",
-    "        )\n",
-    "\n",
-    "    return kernel\n",
-    "\n",
-    "\n",
-    "# Create our kernel\n",
-    "kernel = create_kernel_with_service(service_id=\"process-framework\")\n",
-    "print(\"Kernel created successfully!\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cb1c7b24-8bb5-4b0c-bdc8-2a2ce4e8d5df",
    "metadata": {},
@@ -433,6 +404,45 @@
     "\"\"\")\n",
     "\n",
     "render"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helper function to initialize a Semantic Kernel instance and connect it to the appropriate AI service based on environment settings\n",
+    "\n",
+    "> **⚠️ IMPORTANT:** This kernel service creation service is used in both this simple chatbot process and multi-steop process state example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a5df4f3-14b3-4b47-834b-1bd9b8e6e1aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First we initialize a Semantic Kernel instance and connect it to the appropriate AI service based on environment settings\n",
+    "def create_kernel_with_service(service_id=\"default\"):\n",
+    "    \"\"\"Create a kernel with Azure OpenAI or OpenAI service.\"\"\"\n",
+    "    kernel = Kernel()\n",
+    "\n",
+    "    if (os.getenv(\"AZURE_OPENAI_ENDPOINT\")):\n",
+    "        print(\"Using Azure OpenAI service\")\n",
+    "        kernel.add_service(\n",
+    "            AzureChatCompletion(service_id=service_id)\n",
+    "        )\n",
+    "    else:\n",
+    "        raise ValueError(\n",
+    "            \"No AI service credentials found. Please set up your .env file.\"\n",
+    "        )\n",
+    "\n",
+    "    return kernel\n",
+    "\n",
+    "\n",
+    "# Create our kernel\n",
+    "kernel = create_kernel_with_service(service_id=\"process-framework\")\n",
+    "print(\"Kernel created successfully!\")"
    ]
   },
   {


### PR DESCRIPTION
If rerunning specific example in the processes notebook, running the cell to declare the helper function `create_kernel_with_service` that is used in the simple chatbot and multi-step state examples can be accidentally skipped.

Have moved this cell down to more closely localise where it is first used, with highlighted not it is used also in the following multi-step example.